### PR TITLE
Add build number

### DIFF
--- a/drinks_touch/config.py
+++ b/drinks_touch/config.py
@@ -9,6 +9,15 @@ LDAP_HOST = os.environ.get("LDAP_HOST", "ldap://127.0.0.1")
 LDAP_USER = os.environ.get("LDAP_USER", "cn=admin,dc=flipdot,dc=org")
 LDAP_PW = os.environ.get("LDAP_PW", "admin")
 
+commit_sha_from_env = os.environ.get("BUILD_NUMBER")
+
+if commit_sha_from_env:
+    BUILD_NUMBER = commit_sha_from_env
+else:
+    BUILD_NUMBER = (
+        os.popen("git describe --tags --dirty").read().strip() or "git is not available"
+    )
+
 
 OIDC_DISCOVERY_URL = os.environ.get(
     "OIDC_DISCOVERY_URL",

--- a/drinks_touch/config.py
+++ b/drinks_touch/config.py
@@ -9,10 +9,8 @@ LDAP_HOST = os.environ.get("LDAP_HOST", "ldap://127.0.0.1")
 LDAP_USER = os.environ.get("LDAP_USER", "cn=admin,dc=flipdot,dc=org")
 LDAP_PW = os.environ.get("LDAP_PW", "admin")
 
-commit_sha_from_env = os.environ.get("BUILD_NUMBER")
-
-if commit_sha_from_env:
-    BUILD_NUMBER = commit_sha_from_env
+if bn := os.environ.get("BUILD_NUMBER"):
+    BUILD_NUMBER = bn
 else:
     BUILD_NUMBER = (
         os.popen("git describe --tags --dirty").read().strip() or "git is not available"

--- a/drinks_touch/screens/wait_scan.py
+++ b/drinks_touch/screens/wait_scan.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+import config
 from database.models.scan_event import ScanEvent
 from database.storage import get_session
 from drinks.drinks import get_by_ean
@@ -101,6 +102,15 @@ class WaitScanScreen(Screen):
                 text="Gesamtguthaben aller Member: {}".format(total_balance_fmt),
                 size=25,
                 pos=(125, 755),
+            )
+        )
+
+        self.objects.append(
+            Label(
+                self.screen,
+                text=f"Build: {config.BUILD_NUMBER}",
+                size=20,
+                pos=(0, 785),
             )
         )
 


### PR DESCRIPTION
Determine at runtime via git, if not part of the build-process.

@dargmuesli any idea how we can inject the build number from the build process in the docker image? There is a `with: TAG: ...` in the ci.yml which uses your github action, can and should we access that tag within the Dockerfile?