### PR TITLE
feat(deps): downgrade python to 3.11

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5524,5 +5524,5 @@ cffi = ["cffi (>=1.11)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.13"
-content-hash = "c107518a0c50fed29bf8ba52c4b78b99a9ddbe518dc1fff5268a00f680da08dd"
+python-versions = "^3.11"
+content-hash = "62bd805ba1d25b7187acfb17acaf5754357d1a0382a74146e0777ba0a27113c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["malled"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = "^3.11"
 flask = "^3.0.1"
 flask-compress = "^1.14"
 sudo = "^1.0.0"


### PR DESCRIPTION
Due to the current Python version on the Raspberry Pi (3.11), it's
reasonable to downgrade the project's Python version also to 3.11.