### PR TITLE
Migrate old transactions

### DIFF
--- a/drinks_touch/elements/button.py
+++ b/drinks_touch/elements/button.py
@@ -20,7 +20,7 @@ class Button(BaseElm):
         on_click=None,
         force_width=None,
         force_height=None,
-        inner: BaseElm = None,
+        inner: BaseElm | None = None,
         pos=(0, 0),
         padding: (
             int | tuple[int, int] | tuple[int, int, int] | tuple[int, int, int, int]

--- a/drinks_touch/screens/settings/main_screen.py
+++ b/drinks_touch/screens/settings/main_screen.py
@@ -1,5 +1,3 @@
-import subprocess
-
 from pygame.mixer import Sound
 
 import config
@@ -125,11 +123,3 @@ class SettingsMainScreen(Screen):
             self.sound.play()
             self.clock = 0
         return super().render(dt)
-
-    def update_and_restart(self):
-        # git checkout master
-        # git merge --ff-only origin/master
-        subprocess.run(["git", "checkout", "master"], cwd=config.REPO_PATH)
-        subprocess.run(
-            ["git", "merge", "--ff-only", "origin/master"], cwd=config.REPO_PATH
-        )

--- a/drinks_touch/screens/settings/main_screen.py
+++ b/drinks_touch/screens/settings/main_screen.py
@@ -25,7 +25,7 @@ class SettingsMainScreen(Screen):
             inner=HBox(
                 [
                     SvgIcon(
-                        "drinks_touch/resources/images/volume-2.svg",
+                        "drinks_touch/resources/images/volume-x.svg",
                         height=30,
                         color=config.Color.PRIMARY,
                     ),
@@ -110,12 +110,12 @@ class SettingsMainScreen(Screen):
         color = self.soundcheck_button.inner[0].color
         if self.soundcheck:
             self.soundcheck_button.inner[0] = SvgIcon(
-                img_dir_path / "volume-x.svg", height=height, color=color
+                img_dir_path / "volume-2.svg", height=height, color=color
             )
             self.soundcheck_button.inner[1].text = "Soundcheck aus"
         else:
             self.soundcheck_button.inner[0] = SvgIcon(
-                img_dir_path / "volume-2.svg", height=height, color=color
+                img_dir_path / "volume-x.svg", height=height, color=color
             )
             self.soundcheck_button.inner[1].text = "Soundcheck"
 

--- a/drinks_touch/screens/settings/main_screen.py
+++ b/drinks_touch/screens/settings/main_screen.py
@@ -9,6 +9,7 @@ from screens.settings.git_log_screen import GitLogScreen
 from screens.screen import Screen
 from screens.tasks_screen import TasksScreen
 from tasks import GitFetchTask, UpdateAndRestartTask
+from tasks.migrate_tx import MigrateTxTask
 
 
 class SettingsMainScreen(Screen):
@@ -24,10 +25,10 @@ class SettingsMainScreen(Screen):
                 [
                     SvgIcon(
                         "drinks_touch/resources/images/volume-x.svg",
-                        height=30,
+                        height=40,
                         color=config.Color.PRIMARY,
                     ),
-                    Label(text="Soundcheck", size=25),
+                    Label(text="Soundcheck"),
                 ]
             ),
         )
@@ -82,12 +83,18 @@ class SettingsMainScreen(Screen):
                             [
                                 SvgIcon(
                                     "drinks_touch/resources/images/refresh-cw.svg",
-                                    height=30,
+                                    height=40,
                                     color=config.Color.PRIMARY,
                                 ),
-                                Label(text="Neu initialisieren", size=25),
+                                Label(text="Neu initialisieren"),
                             ]
                         ),
+                    ),
+                    Button(
+                        on_click=lambda: self.goto(
+                            TasksScreen(tasks=[MigrateTxTask()])
+                        ),
+                        text="Migriere Transaktionen",
                     ),
                 ],
                 pos=(5, 300),

--- a/drinks_touch/tasks/barcode_scanner.py
+++ b/drinks_touch/tasks/barcode_scanner.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class InitializeBarcodeScannerTask(BaseTask):
     LABEL = "Initialisiere Barcode-Scanner"
+    ON_STARTUP = True
     thread = None
 
     def run(self):

--- a/drinks_touch/tasks/base.py
+++ b/drinks_touch/tasks/base.py
@@ -21,7 +21,7 @@ class LogHandler(logging.Handler):
 
 
 class BaseTask:
-    ON_STARTUP = True
+    ON_STARTUP = False
 
     def __init__(self):
         self.progress_bar: ProgressBar | None = None

--- a/drinks_touch/tasks/check_for_updates.py
+++ b/drinks_touch/tasks/check_for_updates.py
@@ -5,6 +5,7 @@ import requests
 
 class CheckForUpdatesTask(BaseTask):
     LABEL = "Suche nach drinks-touch updates"
+    ON_STARTUP = True
     newest_version_sha_short = ""
     newest_version_lock = threading.Lock()
 

--- a/drinks_touch/tasks/download_calendar.py
+++ b/drinks_touch/tasks/download_calendar.py
@@ -6,9 +6,10 @@ from tasks.base import BaseTask
 
 class DownloadCalendarTask(BaseTask):
     LABEL = "Lade Kalender herunter"
+    ON_STARTUP = True
 
     def run(self):
-        self.logger.info("Downloaded fd event calendar")
+        self.logger.info("Downloading fd event calendar")
 
         response = requests.get(config.ICAL_URL)
         response.raise_for_status()

--- a/drinks_touch/tasks/migrate_tx.py
+++ b/drinks_touch/tasks/migrate_tx.py
@@ -1,0 +1,140 @@
+from database.models import ScanEvent, Tx, Drink, Account, RechargeEvent
+from database.storage import get_session
+from tasks.base import BaseTask
+
+
+class MigrateTxTask(BaseTask):
+    LABEL = "Migriere Scan- und Rechargeevents zu Transaktionen"
+
+    def run(self):
+        self._migrate_scanevents()
+        self._migrate_rechargeevents()
+        self._check_dangling_txs()
+
+    def _migrate_scanevents(self):
+        session = get_session()
+        self.logger.info("Selecting non-migrated scanevents")
+        scanevents = ScanEvent.query.filter(
+            ScanEvent.tx_id.is_(None),
+        ).all()
+
+        self.logger.info("Found {} scanevents".format(len(scanevents)))
+        for i, scanevent in enumerate(scanevents):
+            if self.sig_killed:
+                break
+            self.progress = (i + 1) / len(scanevents)
+
+            account = Account.query.filter(
+                Account.ldap_id == scanevent.user_id,
+            ).one_or_none()
+
+            if not account:
+                self.logger.warning(
+                    f"Account {scanevent.user_id} not found, skip scanevent #{scanevent.id}"
+                )
+                continue
+
+            drink = Drink.query.filter(
+                Drink.ean == scanevent.barcode,
+            ).one_or_none()
+
+            name = drink.name if drink else "Unbekannt"
+
+            tx = Tx(
+                created_at=scanevent.timestamp,
+                payment_reference=f'Kauf "{name}"',
+                ean=scanevent.barcode,
+                amount=-1,
+                account_id=account.id,
+            )
+            session.add(tx)
+            session.flush()
+            scanevent.tx_id = tx.id
+            session.commit()
+
+    def _migrate_rechargeevents(self):
+        session = get_session()
+        self.logger.info("Selecting non-migrated rechargeevents")
+        rechargeevents = RechargeEvent.query.filter(
+            RechargeEvent.tx_id.is_(None),
+        ).all()
+        self.logger.info("Found {} rechargeevents".format(len(rechargeevents)))
+        for i, rechargeevent in enumerate(rechargeevents):
+            if self.sig_killed:
+                break
+            self.progress = (i + 1) / len(rechargeevents)
+
+            if not rechargeevent.user_id:
+                self.logger.warning(
+                    f"RechargeEvent #{rechargeevent.id} has no user_id, skipping"
+                )
+                continue
+
+            account = Account.query.filter(
+                Account.ldap_id == rechargeevent.user_id,
+            ).one_or_none()
+
+            if not account:
+                self.logger.warning(
+                    f"Account {rechargeevent.user_id} not found, skip rechargeevent #{rechargeevent.id}"
+                )
+                continue
+
+            if rechargeevent.helper_user_id == "DISPLAY":
+                payment_reference = "Aufladung via Display"
+            else:
+                # Try to find a recharge event on the same day for the helper user
+                # with the same amount, but negative. In this case, it's a transfer
+                # to the helper user.
+                is_transfer = session.query(
+                    RechargeEvent.query.filter(
+                        RechargeEvent.helper_user_id == account.name,
+                        RechargeEvent.amount == -rechargeevent.amount,
+                        RechargeEvent.timestamp
+                        >= rechargeevent.timestamp.replace(
+                            hour=0, minute=0, second=0, microsecond=0
+                        ),
+                        RechargeEvent.timestamp
+                        < rechargeevent.timestamp.replace(
+                            hour=23, minute=59, second=59, microsecond=999999
+                        ),
+                    ).exists()
+                ).scalar()
+
+                if is_transfer and rechargeevent.amount > 0:
+                    payment_reference = f"Übertrag von {rechargeevent.helper_user_id}"
+                elif is_transfer and rechargeevent.amount < 0:
+                    payment_reference = f"Übertrag an {rechargeevent.helper_user_id}"
+                else:
+                    payment_reference = "Aufladung via Web"
+
+            tx = Tx(
+                created_at=rechargeevent.timestamp,
+                payment_reference=payment_reference,
+                amount=rechargeevent.amount,
+                account_id=account.id,
+            )
+            session.add(tx)
+            session.flush()
+            rechargeevent.tx_id = tx.id
+            session.commit()
+
+    def _check_dangling_txs(self):
+        """
+        Find transactions that are not linked to any scan or recharge event.
+        """
+        session = get_session()
+        self.logger.info("Checking for dangling transactions")
+        txs = (
+            session.query(Tx)
+            .outerjoin(RechargeEvent, Tx.id == RechargeEvent.tx_id)
+            .outerjoin(ScanEvent, Tx.id == ScanEvent.tx_id)
+            .filter(RechargeEvent.tx_id.is_(None), ScanEvent.tx_id.is_(None))
+            .all()
+        )
+        self.logger.info("Found {} dangling transactions".format(len(txs)))
+        for tx in txs:
+            self.logger.warning(f'Deleting "{tx.payment_reference}" ({tx.id})')
+            session.delete(tx)
+        session.commit()
+        self.logger.info("Deleted dangling transactions")

--- a/drinks_touch/tasks/sync_from_keycloak.py
+++ b/drinks_touch/tasks/sync_from_keycloak.py
@@ -9,6 +9,7 @@ from tasks.base import BaseTask
 
 class SyncFromKeycloakTask(BaseTask):
     LABEL = "Kopiere Nutzer von Keycloak zur Datenbank"
+    ON_STARTUP = True
 
     def run(self):
         self.progress = 0

--- a/drinks_touch/tasks/sync_from_ldap.py
+++ b/drinks_touch/tasks/sync_from_ldap.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 class SyncFromLDAPTask(BaseTask):
     LABEL = "Kopiere Nutzer von LDAP zur Datenbank"
+    ON_STARTUP = True
 
     def run(self):
         def set_progress(progress):


### PR DESCRIPTION
Migrate old "ScanEvent" and "RechargeEvent" to "Tx"

- Match + and - charges and categorize them as a transfer between users
- Differentiate between web and display charges
- Sanity check to see if there are tx that are not referenced by any scan- or rechargeevent
- logger.error on account balance computation, if the new tx model and the old model would yield different account balances