### PR TITLE
Rendering: Implement caching & cache invalidation

### DIFF
--- a/drinks_touch/config.py
+++ b/drinks_touch/config.py
@@ -11,7 +11,7 @@ MONEY_URL = os.environ.get("MONEY_URL", "https://somewhere/x.json")
 MONEY_USER = os.environ.get("MONEY_USER", "my_user")
 MONEY_PASSWORD = os.environ.get("MONEY_PASSWORD", "my_basicauth_passwd")
 
-DEBUG_UI_ELEMENTS = os.environ.get("DEBUG_UI_ELEMENTS", "False") in [
+DEBUG_LEVEL = os.environ.get("DEBUG_LEVEL", "False") in [
     "True",
     "true",
     "1",

--- a/drinks_touch/config.py
+++ b/drinks_touch/config.py
@@ -103,7 +103,7 @@ SCANNER_DEVICE_PATH = os.environ.get("SCANNER_DEVICE_PATH", "/dev/ttyACM0")
 
 WEBSERVER_PORT = os.environ.get("WEBSERVER_PORT", 5002)
 
-FPS = 30
+FPS = 90  # TODO: back to 30, only testing locally
 
 
 class Font(enum.Enum):

--- a/drinks_touch/elements/base_elm.py
+++ b/drinks_touch/elements/base_elm.py
@@ -31,6 +31,8 @@ class BaseElm:
             children = []
         self.children = children
         self.clickable = hasattr(self, "on_click")
+        self.dirty = True
+        self.surface: Surface | None = None
         for child in children:
             if child.clickable:
                 self.clickable = True

--- a/drinks_touch/elements/base_elm.py
+++ b/drinks_touch/elements/base_elm.py
@@ -32,6 +32,7 @@ class BaseElm:
         self.children = children
         self.clickable = hasattr(self, "on_click")
         self.dirty = True
+        self.last_hash = 0
         self.surface: Surface | None = None
         for child in children:
             if child.clickable:
@@ -57,6 +58,26 @@ class BaseElm:
             self.padding_right = padding[1]
             self.padding_bottom = padding[2]
             self.padding_left = padding[3]
+
+    def calculate_hash(self):
+        """
+        Calculate a hash based on the element's properties.
+        This can be used to determine if the element has changed.
+        """
+        return hash(
+            (
+                tuple(self.pos),  # could be a vector, which is unhashable
+                self._height,
+                self._width,
+                self.visible,
+                self.screen_pos,
+                self.padding_top,
+                self.padding_right,
+                self.padding_bottom,
+                self.padding_left,
+                tuple(child.calculate_hash() for child in self.children),
+            )
+        )
 
     @property
     def keyboard_settings(self):
@@ -92,6 +113,15 @@ class BaseElm:
     @property
     def box(self):
         return self.screen_pos + (self.width, self.height)
+
+    def tick(self, dt: float):
+        """
+        Called every frame to update the element.
+        May be used to update animations or other time-based changes.
+        Keep the computation simple to avoid performance issues.
+        """
+        for child in self.children:
+            child.tick(dt)
 
     def event(self, event: pygame.event.Event, pos=None) -> bool:
         """

--- a/drinks_touch/elements/button.py
+++ b/drinks_touch/elements/button.py
@@ -54,6 +54,17 @@ class Button(BaseElm):
         self.disabled = disabled
         self.pass_on_click_kwargs = pass_on_click_kwargs
 
+    def calculate_hash(self):
+        super_hash = super().calculate_hash()
+        properties = (
+            self.disabled,
+            self.bg_color,
+            self.focus,
+        )
+        if self.inner:
+            return hash((super_hash, properties, self.inner.calculate_hash()))
+        return hash((super_hash, properties))
+
     @property
     def text(self):
         return self.inner.text

--- a/drinks_touch/elements/icons/svg.py
+++ b/drinks_touch/elements/icons/svg.py
@@ -40,23 +40,32 @@ class SvgIcon(BaseIcon):
         will be calculated to keep the aspect ratio.
         """
         super().__init__(pos=pos, *args, **kwargs)
-        self.path = Path(path)
         self.color = color
-        image = SvgIcon.load_image(path, color, width, height)
+        self.img_width = width
+        self.img_height = height
+        self.path = Path(path)
 
-        img_width = image.get_width()
-        img_height = image.get_height()
+    def calculate_hash(self):
+        super_hash = super().calculate_hash()
+        return hash((super_hash, self.path, self.color, self.width, self.height))
 
-        self.image = image
-        self.width = img_width + self.padding_left + self.padding_right
-        self.height = img_height + self.padding_top + self.padding_bottom
+    @property
+    def path(self):
+        return self._path
 
+    @path.setter
+    def path(self, value):
+        self._path = value
+        image = SvgIcon.load_image(value, self.color, self.img_width, self.img_height)
         today = datetime.now().date()
         april_fools = today.month == 4 and today.day == 1
         if april_fools:
-            self.image = pygame.transform.flip(
-                self.image, random() > 0.5, random() > 0.5
-            )
+            self.flip_x = random() > 0.5
+            self.flip_y = random() > 0.5
+            image = pygame.transform.flip(image, random() > 0.5, random() > 0.5)
+        self.width = image.get_width() + self.padding_left + self.padding_right
+        self.height = image.get_height() + self.padding_top + self.padding_bottom
+        self.image = image
 
     @classmethod
     @functools.cache

--- a/drinks_touch/elements/input_field.py
+++ b/drinks_touch/elements/input_field.py
@@ -69,6 +69,14 @@ class InputField(BaseElm):
     def __repr__(self):
         return f"<InputField {self.text}>"
 
+    def calculate_hash(self):
+        super_hash = super().calculate_hash()
+        properties = (
+            self.input_type,
+            self.text,
+        )
+        return hash((super_hash, properties))
+
     @property
     def keyboard_settings(self):
         if self.input_type in (InputType.NUMBER, InputType.POSITIVE_NUMBER):

--- a/drinks_touch/elements/label.py
+++ b/drinks_touch/elements/label.py
@@ -57,17 +57,33 @@ class Label(BaseElm):
     def __repr__(self):
         return f"<Label {self.text}>"
 
+    def calculate_hash(self):
+        super_hash = super().calculate_hash()
+        return hash(
+            (
+                super_hash,
+                self.text,
+                self.flip_x,
+                self.flip_y,
+                self.color,
+                self.bg_color,
+                self.border_color,
+                self.border_width,
+            )
+        )
+
     @classmethod
     @functools.cache
     def get_font(cls, font: config.Font, size):
         return pygame.font.Font(font.value, size)
 
-    def render(self, *args, **kwargs) -> pygame.Surface | None:
+    def tick(self, dt: float):
+        if not self.blink_frequency:
+            return
         self.frame_counter += 1
-        if self.blink_frequency:
-            if (self.frame_counter // self.blink_frequency) % 2:
-                return
+        self.visible = (self.frame_counter // self.blink_frequency) % 2 == 0
 
+    def render(self, *args, **kwargs) -> pygame.Surface | None:
         text, pos, area = self._build_text()
         self.width = area.width + self.padding_left + self.padding_right
         self.height = area.height + self.padding_top + self.padding_bottom

--- a/drinks_touch/elements/progress.py
+++ b/drinks_touch/elements/progress.py
@@ -16,7 +16,6 @@ class Progress(BaseElm):
         pos=None,
         size=50,
         color=config.Color.PRIMARY,
-        tick=None,
         speed=1 / 4.0,  # 4 secs
         on_elapsed=None,
         *args,
@@ -24,9 +23,6 @@ class Progress(BaseElm):
     ):
         self.size = size
         self.color = color
-        if tick is None:
-            tick = self.__default_tick
-        self.tick = tick
         self.speed = speed
         self.on_elapsed = on_elapsed
         self.value = 0
@@ -37,6 +33,18 @@ class Progress(BaseElm):
         )
         self.start()
 
+    def calculate_hash(self):
+        super_hash = super().calculate_hash()
+        return hash(
+            (
+                super_hash,
+                self.value,
+                self.is_running,
+                self.size,
+                self.color,
+            )
+        )
+
     def start(self):
         self.value = 0
         self.is_running = True
@@ -44,20 +52,19 @@ class Progress(BaseElm):
     def stop(self):
         self.is_running = False
 
-    def __default_tick(self, old_value, dt):
-        if self.is_running and old_value >= 1:
-            self.stop()
-            if self.on_elapsed:
-                self.on_elapsed()
+    def tick(self, dt: float):
+        if not self.is_running:
+            return
+        if not self.on_elapsed:
+            return
 
-        if self.is_running:
-            return old_value + self.speed * dt
-        else:
-            return old_value
+        self.value += self.speed * dt
+        if self.value >= 1:
+            self.on_elapsed()
 
     def render(self, dt, *args, **kwargs) -> pygame.Surface:
-        if self.tick is not None:
-            self.value = self.tick(self.value, dt)
+        # if self.tick is not None:
+        #     self.value = self.tick(self.value, dt)
 
         surface = pygame.Surface((self.size, self.size), pygame.SRCALPHA)
         if self.is_running:

--- a/drinks_touch/elements/progress_bar.py
+++ b/drinks_touch/elements/progress_bar.py
@@ -42,9 +42,25 @@ class ProgressBar(BaseElm):
 
         self.color = Color.PRIMARY
         self.percent = None
-        self.tick = 0
+        self.forever_bar_pos = 0
         self.font = pygame.font.SysFont("sans serif", 25)
         self.font_mono = pygame.font.Font(config.Font.MONOSPACE.value, 15)
+
+    def calculate_hash(self):
+        super_hash = super().calculate_hash()
+        return hash(
+            (
+                super_hash,
+                self.bar_height,
+                self.text_height,
+                self.label,
+                self.text,
+                self.label_height,
+                self.color,
+                self.percent,
+                self.forever_bar_pos,
+            )
+        )
 
     @property
     def pos_label(self):
@@ -87,8 +103,11 @@ class ProgressBar(BaseElm):
         self.color = Color.PRIMARY
         self.percent = None
 
+    def tick(self, dt: float):
+        self.forever_bar_pos += dt * 300
+
     def render(self, dt, *args, **kwargs) -> pygame.Surface:
-        self.tick += dt
+        # self.tick += dt
         surface = pygame.Surface((self.width, self.height), pygame.SRCALPHA)
 
         x = 0
@@ -173,7 +192,8 @@ class ProgressBar(BaseElm):
             cx, y = 0, 0
             cx -= inner_width / 2
 
-            cx += self.tick * 300 % (self.width + inner_width)
+            # cx += self.tick * 300 % (self.width + inner_width)
+            cx += self.forever_bar_pos % (self.width + inner_width)
 
             x = cx - inner_width / 2
             width = inner_width

--- a/drinks_touch/overlays/keyboard.py
+++ b/drinks_touch/overlays/keyboard.py
@@ -323,7 +323,7 @@ class KeyboardOverlay(BaseOverlay):
         event = pygame.event.Event(pygame.KEYDOWN, key=key, unicode=char)
         self.screen_manager.events([event])
 
-    def render(self, dt):
+    def render(self, dt: float):
         if not self.visible:
             self.clock = 0
             return
@@ -334,9 +334,17 @@ class KeyboardOverlay(BaseOverlay):
         surface.fill((0, 0, 0, 255))
 
         for obj in self.layout:
-            obj_surface = obj.render(dt)
-            if obj_surface is not None:
-                surface.blit(obj_surface, obj.screen_pos)
+            obj.tick(dt)
+            if not obj.visible:
+                continue
+            if obj.last_hash != obj.calculate_hash():
+                obj.dirty = True
+                obj.last_hash = obj.calculate_hash()
+            if obj.dirty:
+                obj.surface = obj.render(dt)
+                obj.dirty = False
+            if obj.surface is not None:
+                surface.blit(obj.surface, obj.screen_pos)
 
         if self.clock < self.ANIMATION_DURATION:
             alpha = int((self.clock / self.ANIMATION_DURATION) * 255)

--- a/drinks_touch/screens/screen.py
+++ b/drinks_touch/screens/screen.py
@@ -36,8 +36,12 @@ class Screen:
         else:
             debug_surface = None
         for o in self.objects:
+            o.tick(dt)
             if not o.visible:
                 continue
+            if o.last_hash != o.calculate_hash():
+                o.dirty = True
+                o.last_hash = o.calculate_hash()
             if o.dirty:
                 o.surface = o.render(dt)
                 o.dirty = False

--- a/drinks_touch/screens/screen.py
+++ b/drinks_touch/screens/screen.py
@@ -38,9 +38,11 @@ class Screen:
         for o in self.objects:
             if not o.visible:
                 continue
-            obj_surface = o.render(dt)
-            if obj_surface is not None:
-                surface.blit(obj_surface, o.screen_pos)
+            if o.dirty:
+                o.surface = o.render(dt)
+                o.dirty = False
+            if o.surface is not None:
+                surface.blit(o.surface, o.screen_pos)
             if ScreenManager.instance.DEBUG_LEVEL >= 3:
                 obj_debug_surface = o.render_debug()
                 if obj_debug_surface is not None:

--- a/drinks_touch/screens/screen_manager.py
+++ b/drinks_touch/screens/screen_manager.py
@@ -153,8 +153,16 @@ class ScreenManager:
                 else self.default_objects
             )
             for obj in obj_list:
-                obj_surface = obj.render(dt)
-                menu_bar.blit(obj_surface, obj.screen_pos)
+                obj.tick(dt)
+                if not obj.visible:
+                    continue
+                if obj.last_hash != obj.calculate_hash():
+                    obj.dirty = True
+                    obj.last_hash = obj.calculate_hash()
+                if obj.dirty:
+                    obj.surface = obj.render(dt)
+                    obj.dirty = False
+                menu_bar.blit(obj.surface, obj.screen_pos)
             # back_surface = pygame.Surface((100, 50))
             # back_surface.fill((255, 0, 255))
             # back_surface.blit(

--- a/drinks_touch/screens/screen_manager.py
+++ b/drinks_touch/screens/screen_manager.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class ScreenManager:
     instance: "ScreenManager" = None
     MENU_BAR_HEIGHT = 65
-    DEBUG_LEVEL = int(config.DEBUG_UI_ELEMENTS)
+    DEBUG_LEVEL = int(config.DEBUG_LEVEL)
     MAX_DEBUG_LEVEL = 3
 
     def __init__(self):

--- a/drinks_touch/screens/settings/main_screen.py
+++ b/drinks_touch/screens/settings/main_screen.py
@@ -181,17 +181,11 @@ class SettingsMainScreen(Screen):
     def toggle_soundcheck(self, button: Button):
         self.soundcheck = not self.soundcheck
         img_dir_path = button.inner[0].path.parent
-        height = button.inner[0].height
-        color = button.inner[0].color
         if self.soundcheck:
-            button.inner[0] = SvgIcon(
-                img_dir_path / "volume-2.svg", height=height, color=color
-            )
+            button.inner[0].path = img_dir_path / "volume-2.svg"
             button.inner[1].text = "Soundcheck aus"
         else:
-            button.inner[0] = SvgIcon(
-                img_dir_path / "volume-x.svg", height=height, color=color
-            )
+            button.inner[0].path = img_dir_path / "volume-x.svg"
             button.inner[1].text = "Soundcheck"
 
     def render(self, dt):


### PR DESCRIPTION
Do not render ALL the things ALL the time. Instead, cache the surfaces of elements and mark objects as dirty if properties that influence the visual appearance change.

If you implement a `BaseElm` yourself, you may need to override `BaseElm.calculate_hash` to include properties that influence the look of your element.