### PR TITLE
Auto onboard via webserver

### DIFF
--- a/drinks_touch/notifications/notification.py
+++ b/drinks_touch/notifications/notification.py
@@ -106,7 +106,7 @@ def format_drinks(drinks_consumed: list[Tx]):
 def get_recent_transactions(account: Account) -> list[Tx]:
     query = select(Tx).where(
         Tx.account_id == account.id,
-        Tx.created_at >= account.last_summary_email_sent_at,
+        Tx.created_at >= (account.last_summary_email_sent_at or datetime.min),
     )
     transactions = Session().execute(query).scalars().all()
     return transactions

--- a/drinks_touch/tasks/sync_from_keycloak.py
+++ b/drinks_touch/tasks/sync_from_keycloak.py
@@ -93,6 +93,7 @@ class SyncFromKeycloakTask(BaseTask):
             account.name = user["username"]
             account.email = user.get("email")
             account.enabled = user["enabled"]
+            account.ldap_path = ldap_entry_dn
             if notification_settings := user["attributes"].get("drink_notification"):
                 account.summary_email_notification_setting = notification_settings[0]
             self.progress = (i + 1) / total_users

--- a/drinks_touch/webserver/webserver.py
+++ b/drinks_touch/webserver/webserver.py
@@ -65,7 +65,17 @@ def load_current_user():
     if oidc.user_loggedin:
         if "account" not in g:
             subject = session["oidc_auth_profile"]["sub"]
-            g.account = db.session.query(Account).filter_by(keycloak_sub=subject).one()
+            g.account = (
+                db.session.query(Account).filter_by(keycloak_sub=subject).one_or_none()
+            )
+            if g.account is None:
+                g.account = Account(
+                    keycloak_sub=subject,
+                    name=session["oidc_auth_profile"]["preferred_username"],
+                    email=session["oidc_auth_profile"]["email"],
+                )
+                db.session.add(g.account)
+                db.session.commit()
     else:
         g.account = None
 


### PR DESCRIPTION
Automatically create a new account on a valid session if no account exists. Fixes #315.

Also fallback compare with datetime.min if no last summary mail was sent. Fixes https://sentry.flipdot.org/organizations/flipdot/issues/112/