### PR TITLE
Remove serial device barcode scanner

### DIFF
--- a/drinks_touch/screens/settings/main_screen.py
+++ b/drinks_touch/screens/settings/main_screen.py
@@ -18,7 +18,6 @@ from tasks import (
     SepaSyncTask,
     SendMailTask,
     SyncFromKeycloakTask,
-    InitializeBarcodeScannerTask,
 )
 
 
@@ -112,23 +111,25 @@ class SettingsMainScreen(Screen):
                         ),
                         width=button_width,
                     ),
-                    Button(
-                        on_click=lambda: self.goto(
-                            TasksScreen(tasks=[InitializeBarcodeScannerTask()])
-                        ),
-                        inner=HBox(
-                            [
-                                SvgIcon(
-                                    "drinks_touch/resources/images/barcode.svg",
-                                    height=40,
-                                    color=config.Color.PRIMARY,
-                                ),
-                                Label(text="Barcode-Scanner Init"),
-                            ],
-                            gap=icon_text_gap,
-                        ),
-                        width=button_width,
-                    ),
+                    # Barcode scanner is now configured to be a keyboard.
+                    # Therefore, no need to initialize serial device
+                    # Button(
+                    #     on_click=lambda: self.goto(
+                    #         TasksScreen(tasks=[InitializeBarcodeScannerTask()])
+                    #     ),
+                    #     inner=HBox(
+                    #         [
+                    #             SvgIcon(
+                    #                 "drinks_touch/resources/images/barcode.svg",
+                    #                 height=40,
+                    #                 color=config.Color.PRIMARY,
+                    #             ),
+                    #             Label(text="Barcode-Scanner Init"),
+                    #         ],
+                    #         gap=icon_text_gap,
+                    #     ),
+                    #     width=button_width,
+                    # ),
                     # Transaction migration was done already.
                     # Keeping it here as long as we have the old data model still in place
                     # Button(

--- a/drinks_touch/tasks/barcode_scanner.py
+++ b/drinks_touch/tasks/barcode_scanner.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 
 class InitializeBarcodeScannerTask(BaseTask):
     LABEL = "Initialisiere Barcode-Scanner"
-    ON_STARTUP = True
+    # Disabled startup, because our barcode scanner is now configured as a keyboard.
+    # This task is only required for serial barcode scanners.
+    ON_STARTUP = False
     thread = None
 
     def run(self):


### PR DESCRIPTION
@malled2002 configured the scanner to be a keyboard. This is way more reliable. Keeping this task enabled causes serial exceptions.